### PR TITLE
docs: add BMWK-EU funding notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,6 @@ Please refer to the [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) file in this reposi
 
 Copyright 2025 SAP SE or an SAP affiliate company and OpenMFP contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/OpenMFP/account-operator).
 
+
+
+<p align="center"><img alt="Bundesministerium für Wirtschaft und Energie (BMWE)-EU funding logo" src="https://apeirora.eu/assets/img/BMWK-EU.png" width="400"/></p>


### PR DESCRIPTION
## Summary

- Adds the BMWK-EU (Bundesministerium für Wirtschaft und Klimaschutz) funding notice to the end of the README as required for all public repositories.